### PR TITLE
Fix filters and search working interchangeably

### DIFF
--- a/anime-archive/src/components/filter/Filter.js
+++ b/anime-archive/src/components/filter/Filter.js
@@ -11,6 +11,13 @@ const Filter = (props) => {
       searchTerm: props.filterAndSearchState.searchTerm,
       genre: null,
       sort: null,
+      status: [
+        "RELEASING",
+        "FINISHED",
+        "NOT_YET_RELEASED",
+        "CANCELLED",
+        "HIATUS",
+      ],
     });
 
     // Grab and set all dropdowns to a variable in an array
@@ -20,6 +27,8 @@ const Filter = (props) => {
     for (let dropdown of allFilters) {
       dropdown.selectedIndex = 0;
     }
+    props.setAnimeData(null);
+    props.setTrigger(true);
   }
 
   return (
@@ -35,6 +44,8 @@ const Filter = (props) => {
       <form className="dropdownFilters">
         {filterData.map((dropdown) => (
           <FilterDropdown
+            setTrigger={props.setTrigger}
+            setAnimeData={props.setAnimeData}
             key={dropdown.id}
             data={dropdown}
             filterAndSearchState={props.filterAndSearchState}

--- a/anime-archive/src/components/filterDropdown/FilterDropdown.js
+++ b/anime-archive/src/components/filterDropdown/FilterDropdown.js
@@ -1,5 +1,4 @@
 import "./FilterDropdown.css";
-
 const FilterDropdown = (props) => {
   // Updates the query object with new value based on filters changed
   function filterHandler(event) {
@@ -8,6 +7,8 @@ const FilterDropdown = (props) => {
       ...props.filterAndSearchState,
       [event.target.name]: event.target.value,
     });
+    props.setAnimeData(null);
+    props.setTrigger(true);
   }
 
   return (


### PR DESCRIPTION
# Description

Fixes issue where search and filters not working together correctly.
Sets standards and behavior for search:
``` 
• A user can filter based on filters alone
• A user can search based on searchTerm alone
• A user can 'load more' anytime data is available
• If a user has a searchTerm and filters active and user inputs new searchTerm -- erase filters and start fresh
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Change Status

- [x] Complete, but not tested (may need new tests)

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] There are no merge conflicts